### PR TITLE
fix: empty response body will cast NullPointerException

### DIFF
--- a/interceptor-core/src/main/java/io/github/dkorobtsov/plinter/core/internal/Printer.java
+++ b/interceptor-core/src/main/java/io/github/dkorobtsov/plinter/core/internal/Printer.java
@@ -232,7 +232,8 @@ final class Printer {
       return EMPTY_STRING;
     }
 
-    if (interceptedResponse.originalBody == null) {
+    if (interceptedResponse.originalBody == null ||
+            interceptedResponse.originalBody.contentLength() <= 0) {
       return logLines(EMPTY_RESPONSE_BODY, true);
     }
 


### PR DESCRIPTION
some http method like "head" with empty response body, will cast NullPointerException