### PR TITLE
Don't run sonar for dependabot triggered PRs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -50,4 +50,7 @@ jobs:
           # Needed to get PR information, if any
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        # Sonar fails for dependabot triggered workflows
+        # Let's disable it (we don't expect any code changes anyway)
+        if: ${{ github.actor != 'dependabot[bot]' }}
         run: ./gradlew sonar


### PR DESCRIPTION
## What?
<!--- Describe the change(s) you are making -->
Let's skip Sonar for Dependabot authored PRs.

## Why?
<!--- Explain why the change(s) is/are necessary -->
1. It's not working
2. We don't expect any code changes anyway

## Checklist:
- [ ] My changes are covered by automated tests
- [ ] I have added or updated documentation

## Optional GIF
<!--- You can add a GIF to make your PR special! -->
![Gif](https://media0.giphy.com/media/BcJbdfFSsJPwK4O66J/200w.webp?cid=ecf05e47j8eq6wbsp7j6ukz1s5xkel2ih3e1htnyg3ok0obk&ep=v1_gifs_search&rid=200w.webp&ct=g)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on disabling Sonar analysis for workflows triggered by dependabot, as it is expected to have no code changes.

### Detailed summary
- Disabled Sonar analysis for workflows triggered by dependabot.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->