### PR TITLE
Fix printing executor tests

### DIFF
--- a/interceptor-tests/src/test/java/io/github/dkorobtsov/tests/BaseTest.java
+++ b/interceptor-tests/src/test/java/io/github/dkorobtsov/tests/BaseTest.java
@@ -48,7 +48,6 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;


### PR DESCRIPTION
## What?
- Refactored `BaseTest.loggingExecutor()` to return both the `ExecutorService` and its specific `Thread` instance using a `Map.Entry`.
- Changed the executor created in `loggingExecutor` from a cached thread pool to a single-thread executor for better test control.
- Updated `ClientPrintingExecutorNegativeTest` to:
    - Use the specific thread returned by `loggingExecutor()` for interruption tests.
    - Implement proper executor shutdown and cleanup in an `@After` method.
    - Remove the dependency on the unreliable `TestUtil.loggingExecutorThread()` method.
- Updated `BaseTest.defaultLoggerConfig` to correctly handle the new return type of `loggingExecutor`.

## Why?
- Addresses issue #11 where tests in `ClientPrintingExecutorNegativeTest` were failing randomly in the CI pipeline.
- The flakiness was caused by race conditions related to:
    - Unreliably finding the correct executor thread to interrupt (`TestUtil.loggingExecutorThread()`).
    - Potential interference between tests due to improper executor lifecycle management (no explicit shutdown).
- These changes ensure the correct thread is always targeted for interruption and that executor resources are properly managed per test, eliminating the race conditions and improving test stability.

## Checklist:
- [X] My changes are covered by automated tests (Existing tests were modified to be reliable)
- [ ] I have added or updated documentation (No documentation changes needed for this fix)

## Optional GIF
<!--- You can add a GIF to make your PR special! -->
![Gif](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExZDZpd2twdTJkd2cwcmpoZW92aTdwdXJxdzcyaDVxZGtjbGxydTN4bCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/dXiAaMqp4mung1KwHB/giphy.gif)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `loggingExecutor()` method in the `BaseTest` class to return both an `ExecutorService` and the created `Thread`. It updates tests in `ClientPrintingExecutorNegativeTest` to utilize this new structure, ensuring proper thread management and shutdown.

### Detailed summary
- Modified `loggingExecutor()` to return a `Map.Entry<ExecutorService, Thread>`.
- Added thread management logic using `AtomicReference` to capture the created thread.
- Updated `ClientPrintingExecutorNegativeTest` to store and shut down the executor correctly.
- Replaced direct calls to `loggingExecutor()` with usage of `executorEntry.getKey()` and `executorEntry.getValue()`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->